### PR TITLE
feat: make `sym_n` search for `h_err` and `h_sp`, or introduce new goals if they are not present

### DIFF
--- a/Arm/BitVec.lean
+++ b/Arm/BitVec.lean
@@ -270,6 +270,7 @@ protected def rand (n : Nat) (lo := 0) (hi := 2^n - 1) : IO (BitVec n) := do
 def unsigned_compare (a b : BitVec n) : Ordering :=
   if BitVec.ult a b then .lt else if a = b then .eq else .gt
 
+@[bitvec_rules]
 abbrev ror (x : BitVec n) (r : Nat) : BitVec n :=
   rotateRight x r
 
@@ -277,7 +278,11 @@ abbrev ror (x : BitVec n) (r : Nat) : BitVec n :=
     the `n`-bit bitvector `x`. -/
 @[bitvec_rules]
 abbrev lsb (x : BitVec n) (i : Nat) : BitVec 1 :=
-  BitVec.ofBool (getLsb x i)
+  -- TODO: We could use
+  --   BitVec.extractLsb' i 1 x
+  -- and avoid the cast here, but unfortunately, extractLsb' isn't supported
+  -- by LeanSAT.
+  (BitVec.extractLsb i i x).cast (by omega)
 
 abbrev partInstall (hi lo : Nat) (val : BitVec (hi - lo + 1)) (x : BitVec n): BitVec n :=
   let mask := allOnes (hi - lo + 1)

--- a/Arm/MinTheory.lean
+++ b/Arm/MinTheory.lean
@@ -22,11 +22,16 @@ attribute [minimal_theory] or_true
 attribute [minimal_theory] true_or
 attribute [minimal_theory] or_false
 attribute [minimal_theory] false_or
+attribute [minimal_theory] if_true_left
+attribute [minimal_theory] if_true_right
+attribute [minimal_theory] if_false_left
+attribute [minimal_theory] if_false_right
 attribute [minimal_theory] iff_self
 attribute [minimal_theory] iff_true
 attribute [minimal_theory] true_iff
 attribute [minimal_theory] iff_false
 attribute [minimal_theory] false_iff
+attribute [minimal_theory] eq_iff_iff
 attribute [minimal_theory] false_implies
 attribute [minimal_theory] implies_true
 attribute [minimal_theory] true_implies

--- a/Correctness/ArmSpec.lean
+++ b/Correctness/ArmSpec.lean
@@ -1,0 +1,21 @@
+import Arm.Exec
+import Correctness.Correctness
+
+namespace Correctness
+
+/-- State machine for the Arm ISA. -/
+instance : Sys ArmState where
+  some := ArmState.default
+  next := stepi
+
+/-- Interpret `Sys.run` as `run` for the Arm state machine. -/
+theorem arm_run (n : Nat) (s : ArmState) :
+  Sys.run s n = run n s := by
+  induction n generalizing s
+  case zero => simp only [Sys.run, run]
+  case succ =>
+    rename_i n h
+    simp only [Sys.run, Sys.next, run]
+    rw [h]
+
+end Correctness

--- a/Correctness/Basic.lean
+++ b/Correctness/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author(s): Leonardo de Moura
+Author(s): Leonardo de Moura, Shilpi Goel
 -/
 
 /--
@@ -44,7 +44,7 @@ A program's specification can be characterized by the following three predicates
 -/
 class Spec (σ : Type) where
   pre  : σ → Prop
-  post : σ → Prop
+  post : σ → σ → Prop
   exit : σ → Prop
 
 /--
@@ -52,8 +52,8 @@ In assertional methods, we specify interesting "cutpoints" of a program using
 `cut` and assertions that must hold at those cutpoints using `assert`.
 -/
 class Spec' (σ : Type) extends Spec σ where
-  cut    : σ → Prop
-  assert : σ → Prop
+  cut    : σ → Bool
+  assert : σ → σ → Prop
 
 /--
 Partial correctness: involves showing that for any state `s` satisfying `pre`,
@@ -62,7 +62,7 @@ such state exists).
 -/
 def PartialCorrectness (σ : Type) [Sys σ] [Spec σ] : Prop :=
   open Spec in
-  ∀ (s : σ) n, pre s → exit (run s n) → ∃ m, m ≤ n ∧ exit (run s m) ∧ post (run s m)
+  ∀ (s : σ) n, pre s → exit (run s n) → ∃ m, m ≤ n ∧ exit (run s m) ∧ post s (run s m)
 
 /--
 Termination: the machine starting from a state `s` satisfying `pre` eventually

--- a/Correctness/Correctness.lean
+++ b/Correctness/Correctness.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author(s): Leonardo de Moura
+Author(s): Leonardo de Moura, Shilpi Goel
 -/
 
 /-
@@ -35,17 +35,18 @@ theorem not_forall_eq_exists_not (p : α → Prop) : (¬ ∀ x, p x) = ∃ x, ¬
     have := h₂ a
     contradiction
 
-/- Result from page 2: I1,I2,I3 implies Partial Correctness. -/
+/- Result from page 2: I1, I2, I3 implies Partial Correctness. -/
 theorem by_inv [Sys σ] [Spec σ] (inv : σ → Prop)
-    (ini  : ∀ s, pre s → inv s)  -- I1
+    (ini  : ∀ s0, pre s0 → inv s0)  -- I1
     (step : ∀ s, inv s → ¬ exit s → inv (next s)) -- I2
-    (stop : ∀ s, inv s → exit s → post s)  -- I3
+    (stop : ∀ s0 sf, inv sf → exit sf → post s0 sf)  -- I3
     : PartialCorrectness σ :=
   fun s n hp he =>
-    let rec find (i : Nat) (h : inv (run s i)) (hle : i ≤ n) : ∃ m : Nat, m ≤ n ∧ exit (run s m) ∧ post (run s m) :=
+    let rec find (i : Nat) (h : inv (run s i)) (hle : i ≤ n)
+            : ∃ m : Nat, m ≤ n ∧ exit (run s m) ∧ post s (run s m) :=
       if hn : i < n then
         if he : exit (run s i) then
-          ⟨i, Nat.le_of_lt hn, he, stop _ h he⟩
+          ⟨i, Nat.le_of_lt hn, he, stop _ _ h he⟩
         else
           have : inv (run s (i+1)) := by
             rw [← next_run]; exact step _ h he
@@ -54,7 +55,7 @@ theorem by_inv [Sys σ] [Spec σ] (inv : σ → Prop)
         have := Nat.ge_of_not_lt hn
         have := Nat.le_antisymm this hle
         have hinv : inv (run s n) := by subst this; assumption
-        have hpost : post (run s n) := stop _ hinv he
+        have hpost : post s (run s n) := stop _ _ hinv he
         ⟨n, Nat.le_refl _, he, hpost⟩
     find 0 (ini _ hp) (Nat.zero_le _)
 
@@ -97,11 +98,13 @@ noncomputable def nextc [Sys σ] [Spec' σ] (s : σ) : σ :=
   else
     d
 
-theorem csteps_cut [Sys σ] [Spec' σ] {s : σ} (h : cut s) (i : Nat) : csteps s i = i := by
+theorem csteps_cut [Sys σ] [Spec' σ] {s : σ} (h : cut s) (i : Nat) :
+  csteps s i = i := by
   rw [csteps_eq]
   simp [*]
 
-theorem csteps_not_cut [Sys σ] [Spec' σ] {s : σ} (h₁ : ¬ cut s) (h₂ : csteps (next s) (i+1) = j) : csteps s i = j := by
+theorem csteps_not_cut [Sys σ] [Spec' σ] {s : σ} (h₁ : ¬ cut s)
+  (h₂ : csteps (next s) (i+1) = j) : csteps s i = j := by
   rw [csteps_eq]
   simp [h₁]
   assumption
@@ -109,7 +112,8 @@ theorem csteps_not_cut [Sys σ] [Spec' σ] {s : σ} (h₁ : ¬ cut s) (h₂ : cs
 /--
 Helper theorem. Given a state `s` and `cut (run s n)` for `n`, then there is
 `k` such that `csteps s 0 = k` and `k ≤ n`.
-Note that `cut (run s n)` ensures `csteps s 0` terminates because we will find a `cut` in at most `n` steps.
+Note that `cut (run s n)` ensures `csteps s 0` terminates because we will find a
+`cut` in at most `n` steps.
 -/
 theorem find_next_cut [Sys σ] [Spec' σ] (s : σ) (hc : cut (run s n)) :
   ∃ k : Nat, csteps s 0 = k ∧ k ≤ n ∧ cut (run s k) :=
@@ -129,29 +133,32 @@ theorem find_next_cut [Sys σ] [Spec' σ] (s : σ) (hc : cut (run s n)) :
   loop s 0 (Nat.zero_le ..) rfl
 
 /--
-Theorem 1 from page 5. It shows that if V1-V4 hold, then we have partial
-correctness.
+Theorem 1 from page 5. If V1-V4 hold, then we have partial correctness.
+
+We use `s0`, `si`, and `sf` to refer to initial, intermediate, and final (exit)
+states respectively.
 -/
 theorem partial_correctness_from_verification_conditions [Sys σ] [Spec' σ]
-    (v1 : ∀ s : σ, pre s → assert s)
-    (v2 : ∀ s : σ, exit s → cut s)
-    (v3 : ∀ s : σ, assert s → exit s → post s)
-    (v4 : ∀ s : σ, assert s → ¬ exit s → assert (nextc (next s)))
+    (v1 : ∀ s0 : σ, pre s0 → assert s0 s0)
+    (v2 : ∀ sf : σ, exit sf → cut sf)
+    (v3 : ∀ s0 sf : σ, assert s0 sf → exit sf → post s0 sf)
+    (v4 : ∀ s0 si : σ, assert s0 si → ¬ exit si → assert s0 (nextc (next si)))
     : PartialCorrectness σ :=
-  fun s n hp hexit =>
-    let rec find (i : Nat) (h : assert (run s i)) (hle : i ≤ n) : ∃ m : Nat, m ≤ n ∧ exit (run s m) ∧ post (run s m) :=
+  fun s0 n hp hexit =>
+    let rec find (i : Nat) (h : assert s0 (run s0 i)) (hle : i ≤ n) :
+                 ∃ m : Nat, m ≤ n ∧ exit (run s0 m) ∧ post s0 (run s0 m) :=
       if hn : i < n then
-        if he : exit (run s i) then
-          ⟨i, Nat.le_of_lt hn, he, v3 _ h he⟩
+        if he : exit (run s0 i) then
+          ⟨i, Nat.le_of_lt hn, he, v3 _ _ h he⟩
         else
-          have : cut (run (run s (i + 1)) (n - Nat.succ i)) := by
+          have : cut (run (run s0 (i + 1)) (n - Nat.succ i)) := by
             rw [run_run, Nat.add_one, Nat.add_sub_cancel' hn]
             exact v2 _ hexit
-          have ⟨k, hk, hlek, hck⟩ := find_next_cut (run s (i+1)) this
+          have ⟨k, hk, hlek, hck⟩ := find_next_cut (run s0 (i+1)) this
           have hle' : i + 1 + k ≤ n := by
             exact (Nat.le_sub_iff_add_le' hn).mp hlek
-          have : assert (nextc (next (run s i))) := v4 _ h he
-          have h' : assert (run s (i + 1 + k)) := by
+          have : assert s0 (nextc (next (run s0 i))) := v4 _ _ h he
+          have h' : assert s0 (run s0 (i + 1 + k)) := by
             rw [run_run] at hck
             rw [nextc, next_run, hk, run_run] at this
             simp [hck] at this
@@ -162,9 +169,9 @@ theorem partial_correctness_from_verification_conditions [Sys σ] [Spec' σ]
       else
         have := Nat.ge_of_not_lt hn
         have := Nat.le_antisymm this hle
-        have ha : assert (run s n) := by subst this; assumption
-        have hpost : post (run s n) := v3 _ ha hexit
+        have ha : assert s0 (run s0 n) := by subst this; assumption
+        have hpost : post s0 (run s0 n) := v3 _ _ ha hexit
         ⟨n, Nat.le_refl _, hexit, hpost⟩
-    find 0 (v1 _ hp) (Nat.zero_le ..)
+    find 0 (v1 s0 hp) (Nat.zero_le ..)
 
 end Correctness

--- a/Proofs/AES-GCM/GCMGmultV8Sym.lean
+++ b/Proofs/AES-GCM/GCMGmultV8Sym.lean
@@ -16,8 +16,7 @@ theorem gcm_gmult_v8_program_run_27 (s0 sf : ArmState)
     (h_run : sf = run gcm_gmult_v8_program.length s0) :
     read_err sf = .None := by
   simp (config := {ground := true}) only [Option.some.injEq] at h_s0_pc h_run
-  simp_all only [state_simp_rules, -h_run]
-  sym1_i_n 0 27 h_s0_program
+  sym1_n 27
   subst h_run
   assumption
   done

--- a/Proofs/Experiments/AbsVCG.lean
+++ b/Proofs/Experiments/AbsVCG.lean
@@ -1,0 +1,333 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Shilpi Goel
+
+Experimental: Use the Correctness module to prove that this program implements
+absolute value correctly. The objective of this exercise is to determine the
+"shape" of the lemmas that are needed for automation and/or to modify the
+definitions in Correctness, if needed.
+-/
+import Arm
+import Tactics.StepThms
+import Tactics.Sym
+import Correctness.ArmSpec
+import Lean
+
+namespace AbsVCG
+
+def program : Program :=
+  def_program
+   [
+    (0x4005d0#64, 0x2a0003e1#32), --  mov w1, w0
+    (0x4005d4#64, 0x131f7c00#32), --  asr w0, w0, #31
+    (0x4005d8#64, 0x0b000021#32), --  add w1, w1, w0
+    (0x4005dc#64, 0x4a000020#32), --  eor w0, w1, w0
+    (0x4005e0#64, 0xd65f03c0#32)] --  ret
+
+/-- Precondition for the correctness of the `Abs` program. -/
+def abs_pre (s : ArmState) : Prop :=
+  read_pc s = 0x4005d0#64 ∧
+  s.program = program ∧
+  read_err s = StateError.None
+
+/-- Specification of the absolute value computation for a 32-bit bitvector. -/
+def spec (x : BitVec 32) : BitVec 32 :=
+  -- We prefer the current definition as opposed to:
+  -- BitVec.ofNat 32 x.toInt.natAbs
+  -- because the above has functions like `toInt` that do not play well with
+  -- bitblasting/LeanSAT.
+  let msb := BitVec.extractLsb 31 31 x
+  if msb == 0#1 then
+    x
+  else
+    (0#32 - x)
+
+/-- Postcondition for the correctness of the `Abs` program. -/
+def abs_post (s0 sf : ArmState) : Prop :=
+  read_gpr 32 0#5 sf = spec (read_gpr 32 0#5 s0) ∧
+  read_err sf = StateError.None
+
+/-- Function identifying the exit state(s) of the program. -/
+def abs_exit (s : ArmState) : Prop :=
+  -- (FIXME) Let's consider the state where we are poised to execute `ret` as an
+  -- exit state for now.
+  read_pc s = 0x4005e0#64
+
+/-- Function identifying the cutpoints of the program. -/
+def abs_cut (s : ArmState) : Bool :=
+  read_pc s = 0x4005d0#64 -- First instruction
+  ||
+  read_pc s = 0x4005e0#64 -- Last instruction
+
+/-- Function that attaches assertions at the cutpoints of this program. -/
+def abs_assert (s0 si : ArmState) : Prop :=
+  abs_pre s0 ∧
+  if read_pc si = 0x4005d0#64 then
+    si = s0
+  else if read_pc si = 0x4005e0#64 then
+    abs_post s0 si
+  else
+    False
+
+instance : Spec' ArmState where
+  pre    := abs_pre
+  post   := abs_post
+  exit   := abs_exit
+  cut    := abs_cut
+  assert := abs_assert
+
+theorem Abs.csteps_eq (s : ArmState) (i : Nat) :
+  Correctness.csteps s i = if abs_cut s then i
+                           else Correctness.csteps (stepi s) (i + 1) := by
+  rw [Correctness.csteps_eq]
+  simp only [Sys.next, Spec'.cut]
+  done
+
+-------------------------------------------------------------------------------
+-- Generating the program effects and non-effects
+
+-- set_option trace.gen_step.print_names true in
+#genStepTheorems program namePrefix:="abs_" thmType:="fetch"
+-- set_option trace.gen_step.print_names true in
+#genStepTheorems program namePrefix:="abs_" thmType:="decodeExec"
+-- set_option trace.gen_step.print_names true in
+#genStepTheorems program namePrefix:="abs_" thmType:="step" `state_simp_rules
+
+-- (FIXME) Obtain *_cut theorems for each instruction automatically.
+
+theorem abs_stepi_0x4005d0_cut (s : ArmState)
+  (h_program : s.program = program)
+  (h_pc : r StateField.PC s = 0x4005d0#64)
+  (h_err : r StateField.ERR s = StateError.None) :
+  abs_cut (stepi s) = false := by
+  have := abs_stepi_0x4005d0 s (stepi s) h_program h_pc h_err
+  simp only [minimal_theory] at this
+  simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
+  done
+
+theorem abs_stepi_0x4005d4_cut (s : ArmState)
+  (h_program : s.program = program)
+  (h_pc : r StateField.PC s = 0x4005d4#64)
+  (h_err : r StateField.ERR s = StateError.None) :
+  abs_cut (stepi s) = false := by
+  have := abs_stepi_0x4005d4 s (stepi s) h_program h_pc h_err
+  simp only [minimal_theory] at this
+  simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
+  done
+
+theorem abs_stepi_0x4005d8_cut (s : ArmState)
+  (h_program : s.program = program)
+  (h_pc : r StateField.PC s = 0x4005d8#64)
+  (h_err : r StateField.ERR s = StateError.None) :
+  abs_cut (stepi s) = false := by
+  have := abs_stepi_0x4005d8 s (stepi s) h_program h_pc h_err
+  simp only [minimal_theory] at this
+  simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
+  done
+
+theorem abs_stepi_0x4005dc_cut (s : ArmState)
+  (h_program : s.program = program)
+  (h_pc : r StateField.PC s = 0x4005dc#64)
+  (h_err : r StateField.ERR s = StateError.None) :
+  abs_cut (stepi s) = true := by
+  have := abs_stepi_0x4005dc s (stepi s) h_program h_pc h_err
+  simp only [minimal_theory] at this
+  simp only [abs_cut, this, state_simp_rules, bitvec_rules, minimal_theory]
+  done
+
+/--
+(FIXME) This was tedious: we need to prove helper lemmas/build automation to
+generate these effects theorems, but the good news is that we see a
+pattern here to exploit. Our main workhorse here is symbolic
+simulation, but the interesting part is that we are symbolically simulating
+as well as determining the number of steps to simulate in tandem.
+-/
+theorem program_effects_lemma (h_pre : abs_pre s0)
+  (h_run : sf = run (Correctness.csteps (stepi s0) 0) (stepi s0)) :
+  r (StateField.GPR 0#5) sf = BitVec.truncate 64
+      (BitVec.zeroExtend 32
+        (BitVec.zeroExtend 64
+          (AddWithCarry (BitVec.zeroExtend 32 (BitVec.zeroExtend 64 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0))))
+              (BitVec.zeroExtend 32
+                (BitVec.truncate 64
+                      (BitVec.replicate 32
+                        (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)))) &&&
+                    BitVec.truncate 64 (~~~1#32) |||
+                  (BitVec.truncate 64 (BitVec.zero 32) &&& BitVec.truncate 64 (~~~4294967295#32) |||
+                      BitVec.truncate 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)).rotateRight 31) &&&
+                        BitVec.truncate 64 4294967295#32) &&&
+                    BitVec.truncate 64 1#32))
+              0#1).fst)) ^^^
+    BitVec.truncate 64
+      (BitVec.zeroExtend 32
+        (BitVec.truncate 64
+              (BitVec.replicate 32 (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)))) &&&
+            BitVec.truncate 64 (~~~1#32) |||
+          (BitVec.truncate 64 (BitVec.zero 32) &&& BitVec.truncate 64 (~~~4294967295#32) |||
+              BitVec.truncate 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)).rotateRight 31) &&&
+                BitVec.truncate 64 4294967295#32) &&&
+            BitVec.truncate 64 1#32)) ∧
+  r StateField.PC sf = 0x4005e0#64 ∧
+  r StateField.ERR sf = StateError.None := by
+
+  simp only [abs_pre, state_simp_rules] at h_pre
+  have ⟨h_s0_pc, h_s0_program, h_s0_err⟩ := h_pre; clear h_pre
+
+  -- Instruction 1
+  rw [Abs.csteps_eq, abs_stepi_0x4005d0_cut s0 h_s0_program h_s0_pc h_s0_err] at h_run
+  simp only [minimal_theory, Nat.reduceAdd] at h_run
+  generalize h_step_1 : stepi s0 = s1 at h_run
+  have h_s1 : s1 = run 1 s0 := by
+    simp only [run, h_step_1]
+  replace h_step_1 : s1 = stepi s0 := h_step_1.symm
+  rw [abs_stepi_0x4005d0 s0 s1 h_s0_program h_s0_pc h_s0_err] at h_step_1
+  have h_s1_program : s1.program = program := by
+    simp only [h_step_1, h_s0_program,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s1_err : r StateField.ERR s1 = StateError.None := by
+    simp only [h_step_1, h_s0_err,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s1_pc : r StateField.PC s1 = 0x4005d4#64 := by
+    simp only [h_step_1, h_s0_pc,
+               state_simp_rules, minimal_theory, bitvec_rules]
+
+  -- Instruction 2
+  rw [Abs.csteps_eq, abs_stepi_0x4005d4_cut s1 h_s1_program h_s1_pc h_s1_err] at h_run
+  simp only [minimal_theory, Nat.reduceAdd] at h_run
+  generalize h_step_2 : stepi s1 = s2 at h_run
+  have h_s2 : s2 = run 1 s1 := by
+    simp only [run, h_step_2]
+  replace h_step_2 : s2 = stepi s1 := h_step_2.symm
+  rw [abs_stepi_0x4005d4 s1 s2 h_s1_program h_s1_pc h_s1_err] at h_step_2
+  -- (FIXME) abs_stepi_0x4005d4 should have reduced `decode_bit_masks`.
+  simp only [reduceDecodeBitMasks] at h_step_2
+  have h_s2_program : s2.program = program := by
+    simp only [h_step_2, h_s1_program,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s2_err : r StateField.ERR s2 = StateError.None := by
+    simp only [h_step_2, h_s1_err,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s2_pc : r StateField.PC s2 = 0x4005d8#64 := by
+    simp only [h_step_2, h_s1_pc,
+               state_simp_rules, minimal_theory, bitvec_rules]
+
+  -- Instruction 3
+  rw [Abs.csteps_eq, abs_stepi_0x4005d8_cut s2 h_s2_program h_s2_pc h_s2_err] at h_run
+  simp only [minimal_theory, Nat.reduceAdd] at h_run
+  generalize h_step_3 : stepi s2 = s3 at h_run
+  have h_s3 : s3 = run 1 s2 := by
+    simp only [run, h_step_3]
+  replace h_step_3 : s3 = stepi s2 := h_step_3.symm
+  rw [abs_stepi_0x4005d8 s2 s3 h_s2_program h_s2_pc h_s2_err] at h_step_3
+  have h_s3_program : s3.program = program := by
+    simp only [h_step_3, h_s2_program,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s3_err : r StateField.ERR s3 = StateError.None := by
+    simp only [h_step_3, h_s2_err,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s3_pc : r StateField.PC s3 = 0x4005dc#64 := by
+    simp only [h_step_3, h_s2_pc,
+               state_simp_rules, minimal_theory, bitvec_rules]
+
+  -- Instruction 4
+  rw [Abs.csteps_eq, abs_stepi_0x4005dc_cut s3 h_s3_program h_s3_pc h_s3_err] at h_run
+  simp only [minimal_theory, Nat.reduceAdd] at h_run
+  generalize h_step_4 : stepi s3 = s4 at h_run
+  have h_s4 : s4 = run 1 s3 := by
+    simp only [run, h_step_4]
+  replace h_step_4 : s4 = stepi s3 := h_step_4.symm
+  rw [abs_stepi_0x4005dc s3 s4 h_s3_program h_s3_pc h_s3_err] at h_step_4
+  have _h_s4_program : s4.program = program := by
+    simp only [h_step_4, h_s3_program,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s4_err : r StateField.ERR s4 = StateError.None := by
+    simp only [h_step_4, h_s3_err,
+               state_simp_rules, minimal_theory, bitvec_rules]
+  have h_s4_pc : r StateField.PC s4 = 0x4005e0#64 := by
+    simp only [h_step_4, h_s3_pc,
+               state_simp_rules, minimal_theory, bitvec_rules]
+
+  have h_s4_gpr0 : r (StateField.GPR 0#5) s4 =
+    BitVec.truncate 64
+      (BitVec.zeroExtend 32
+        (BitVec.zeroExtend 64
+          (AddWithCarry (BitVec.zeroExtend 32 (BitVec.zeroExtend 64 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0))))
+              (BitVec.zeroExtend 32
+                (BitVec.truncate 64
+                      (BitVec.replicate 32
+                        (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)))) &&&
+                    BitVec.truncate 64 (~~~1#32) |||
+                  (BitVec.truncate 64 (BitVec.zero 32) &&& BitVec.truncate 64 (~~~4294967295#32) |||
+                      BitVec.truncate 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)).rotateRight 31) &&&
+                        BitVec.truncate 64 4294967295#32) &&&
+                    BitVec.truncate 64 1#32))
+              0#1).fst)) ^^^
+    BitVec.truncate 64
+      (BitVec.zeroExtend 32
+        (BitVec.truncate 64
+              (BitVec.replicate 32 (BitVec.extractLsb 31 31 (BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)))) &&&
+            BitVec.truncate 64 (~~~1#32) |||
+          (BitVec.truncate 64 (BitVec.zero 32) &&& BitVec.truncate 64 (~~~4294967295#32) |||
+              BitVec.truncate 64 ((BitVec.zeroExtend 32 (r (StateField.GPR 0#5) s0)).rotateRight 31) &&&
+                BitVec.truncate 64 4294967295#32) &&&
+            BitVec.truncate 64 1#32)) := by
+    simp (config := {decide := true}) only [h_step_4, h_step_3, h_step_2, h_step_1,
+                                            state_simp_rules]
+
+  have h_sf_s4 : sf = s4 := by
+    simp only [h_run, h_s4, h_s3, h_s2, h_s1, run]
+
+  simp only [h_sf_s4, h_s4_gpr0, h_s4_pc, h_s4_err, minimal_theory]
+  done
+
+-------------------------------------------------------------------------------
+
+theorem partial_correctness :
+  PartialCorrectness ArmState := by
+  apply Correctness.partial_correctness_from_verification_conditions
+  case v1 =>
+    intros s0 h_pre
+    simp only [Spec'.assert, abs_assert]
+    simp only [Spec.pre] at h_pre
+    simp_all only [abs_pre, minimal_theory]
+  case v2 =>
+    intro sf h_exit
+    simp only [Spec.exit, abs_exit] at h_exit
+    simp only [Spec'.cut, abs_cut]
+    simp_all only [minimal_theory]
+  case v3 =>
+    intro s0 sf
+    simp only [Spec'.assert, Spec.exit, Spec.post, abs_assert, abs_exit]
+    intros h1 h2
+    simp_all (config := {decide := true}) only [minimal_theory]
+  case v4 =>
+    intro s0 si h_assert h_exit
+    simp [Spec.exit, abs_exit] at h_exit
+    simp only [Spec'.assert, abs_assert, h_exit, minimal_theory] at h_assert
+    have ⟨h_assert1, h_assert2, h_assert3⟩ := h_assert
+    subst si
+    clear h_exit h_assert
+    generalize h_run : (run (Correctness.csteps (stepi s0) 0) (stepi s0)) = sf
+    have effects := @program_effects_lemma s0 sf h_assert1 h_run.symm
+    simp only [Sys.next, Spec'.assert, abs_assert, h_assert1,
+               Correctness.nextc, Correctness.arm_run,
+               h_run, effects, Spec'.cut, abs_cut,
+               Spec'.assert, abs_assert, abs_post,
+               AddWithCarry, spec,
+               state_simp_rules, bitvec_rules, minimal_theory]
+    split <;> bv_decide
+    done
+
+theorem termination :
+  Termination ArmState := by
+  simp [Termination, Spec.pre, Spec.exit, abs_exit,
+        state_simp_rules, bitvec_rules, minimal_theory]
+  intro s h_pre
+  have h_effects := @program_effects_lemma s
+  simp only [h_pre, minimal_theory] at h_effects
+  apply Exists.intro ((Correctness.csteps (Sys.next s) 0) + 1)
+  simp only [Correctness.arm_run, Sys.next, run_succ, h_effects]
+  done
+
+end AbsVCG

--- a/Proofs/Proofs.lean
+++ b/Proofs/Proofs.lean
@@ -14,3 +14,4 @@ import Proofs.Experiments.MemoryAliasing
 import Proofs.Experiments.SHA512MemoryAliasing
 import Proofs.Experiments.Max
 import Proofs.Experiments.Abs
+import Proofs.Experiments.AbsVCG

--- a/Tactics/SymContext.lean
+++ b/Tactics/SymContext.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author(s): Alex Keizer
+-/
+import Lean
+import Arm.Exec
+
+/-!
+This files defines the `SymContext` structure,
+which collects the names of various
+variables/hypotheses in the local context required for symbolic evaluation.
+
+The canonical way to construct a `SymContext` is through `fromLocalContext`,
+which searches the local context (up to def-eq) for variables and hypotheses of
+the expected types.
+
+Alternatively, there is `SymContext.default`,
+which returns a context using hard-coded names,
+simply assuming those hypotheses to be present
+without looking at the local context.
+This function exists for backwards compatibility,
+and is likely to be deprecated and removed in the near future. -/
+
+open Lean Meta
+open BitVec
+
+/-- A `SymContext` collects the names of various variables/hypotheses in
+the local context required for symbolic evaluation -/
+structure SymContext where
+  /-- `state` is a local variable of type `ArmState` -/
+  state : Name
+  -- TODO: Should we eventually track the final state as well?
+  --       We could use it to avoid introducing the last intermediate state,
+  --       when we detect that `runSteps = 0`
+  /-- `runSteps` is the number of steps that we can *maximally* simulate,
+  because of the way it occurs in `h_run`.
+  Note that `runSteps` is a meta-level natural number, reflecting the fact that
+  we expect the number of steps in `h_run` to be expressed as a concrete literal
+  -/
+  runSteps : Nat
+  /-- `h_run` is a local hypothesis of the form
+  `finalState = run {runSteps} state` -/
+  h_run : Name
+  /-- `program` is a *constant* which represents the program being evaluated -/
+  program : Name
+  /-- `h_program` is a local hypothesis of the form `state.program = program` -/
+  h_program : Name
+  /-- `pc` is the *concrete* value of the program counter
+
+  Note that for now we only support symbolic evaluation of programs
+  at statically known addresses.
+  At some point in the near future,
+  we will want to support addresses of the type `base + / - offset` as well,
+  where `base` is an arbitrary variable and `offset` is statically known.
+  We could do so by refactoring `pc` to be of type `Bool × BitVec 64`,
+  so long as we assume the instruction addresses in a single program will
+  either be all statically known, or all offset against the same `base` address,
+  and we assume that no overflow happens
+  (i.e., `base - x` can never be equal to `base + y`) -/
+  pc : BitVec 64
+  /-- `h_pc` is a local hypothesis of the form `r StateField.PC state = pc` -/
+  h_pc  : Name
+  /-- `h_err` is a local hypothesis of the form
+  `r StateField.ERR state = .None` -/
+  h_err : Option Name
+  /-- `h_sp` is a local hypothesis of the form `CheckSPAlignment state` -/
+  h_sp  : Option Name
+
+  /-- `state_prefix` is used together with `curr_state_number`
+  to determine the name of the next state variable that is added by `sym` -/
+  state_prefix      : String := "s"
+  /-- `curr_state_number` is incremented each simulation step,
+  and used together with `curr_state_number`
+  to determine the name of the next state variable that is added by `sym` -/
+  curr_state_number : Nat := 0
+
+
+namespace SymContext
+
+/-! ## Creating initial contexts -/
+
+/-- Infer `state_prefix` and `curr_state_number` from the `state` name
+as follows: if `state` is `s{i}` for some number `i` and a single character `s`,
+then `s` is the prefix and `i` the number,
+otherwise ignore `state`, and start counting from `s1` -/
+def inferStatePrefixAndNumber (ctxt : SymContext) : SymContext :=
+  let state := ctxt.state.toString
+  let tail := state.toSubstring.drop 1
+
+  if let some curr_state_number := tail.toNat? then
+    { ctxt with
+      state_prefix := (state.get? 0).getD 's' |>.toString,
+      curr_state_number }
+  else
+    { ctxt with
+      state_prefix := "s",
+      curr_state_number := 1 }
+
+/-- Given a ground term `e` of type `Nat`, fully reduce it,
+and attempt to reflect it into a meta-level `Nat` -/
+private def reflectNatLiteral (e : Expr) : MetaM Nat := do
+  if e.hasFVar then
+    throwError "Expected a ground term, but {e} has free variables"
+
+  let e' ← reduce (← instantiateMVars e)
+  let some x := e'.rawNatLit?
+    | throwError "Expected a numeric literal, found:\n\t{e'}
+which was obtained by reducing:\n\t{e}"
+  -- ^^ The previous reduction will have reduced a canonical-form nat literal
+  --    into a raw literal, hence, we use `rawNatLit?` rather than `nat?`
+  return x
+
+/-- For a concrete width `w`,
+reduce an expression `e` (of type `BitVec w`) to be of the form `?n#w`,
+and then reflect `?n` to build the meta-level bitvector -/
+private def reflectBitVecLiteral (w : Nat) (e : Expr) : MetaM (BitVec w) := do
+  if e.hasFVar then
+    throwError "Expected a ground term, but {e} has free variables"
+
+  let x ← mkFreshExprMVar (Expr.const ``Nat [])
+  let e' ← mkAppM ``BitVec.ofNat #[toExpr w, x]
+  if (←isDefEq e e') then
+    return BitVec.ofNat w (← reflectNatLiteral x)
+  else
+    throwError "Failed to unify, expected:\n\t{e'}\nbut found:\n\t{e'}"
+
+/-- Attempt to look-up a `name` in the local context,
+so that we can build an expression with its fvarid,
+to return a message with nice highlighting.
+If lookup fails, we return a message with the plain name, wihout highlighting -/
+private def userNameToMessageData (name : Name) : MetaM MessageData := do
+  return match (← getLCtx).findFromUserName? name with
+    | some decl => m!"{Expr.fvar decl.fvarId}"
+    | none      => m!"{name}"
+
+/-- Annotate any errors thrown by `k` with a local variable (and its type) -/
+private def withErrorContext (name : Name) (type? : Option Expr) (k : MetaM α) :
+    MetaM α :=
+  try k catch e =>
+    let h ← userNameToMessageData name
+    let type := match type? with
+      | some type => m!" : {type}"
+      | none      => m!""
+    throwErrorAt e.getRef "{e.toMessageData}\n\nIn {h}{type}"
+
+
+def fromLocalContext (state? : Option Name) : MetaM SymContext := do
+  let lctx ← getLCtx
+
+  -- Either get the state expression from the local context,
+  -- or, if no state was given, create a new meta variable for the state
+  let stateExpr : Expr ← match state? with
+    | some state =>
+      let some decl := lctx.findFromUserName? state
+        | throwError "Unknown local variable `{state}`"
+      pure (Expr.fvar decl.fvarId)
+    | none => mkFreshExprMVar (Expr.const ``ArmState [])
+
+  -- Find `h_run` and infer `runSteps` from it
+  let sf ← mkFreshExprMVar none
+  let runSteps ← mkFreshExprMVar (Expr.const ``Nat [])
+  let h_run_type ← mkEq sf (←mkAppM ``run #[runSteps, stateExpr])
+  let h_run ← findLocalDeclUsernameOfTypeOrError h_run_type
+
+  -- Unwrap and reflect `runSteps`
+  let runSteps ← withErrorContext h_run h_run_type <| reflectNatLiteral runSteps
+  -- TODO: we should allow all ground terms here, not just literals.
+  -- For example, we sometimes use `sf = run someProgram.length s0`
+
+  -- At this point, `stateExpr` should have been assigned (if it was an mvar),
+  -- so we can unwrap it to get the underlying name
+  let stateExpr ← instantiateMVars stateExpr
+  let state ← state?.getDM <| do
+    let .fvar state := stateExpr
+      | let h_run ← userNameToMessageData h_run
+        throwError
+  "Expected a free variable, found:
+    {stateExpr}
+  We inferred this as the initial state because we found:
+    {h_run} : {← instantiateMVars h_run_type}
+  in the local context.
+
+  If this is wrong, please explicitly provide the right initial state,
+  as in `sym {runSteps} at ?s0`
+  "
+    let some state := lctx.find? state
+      /- I don't expect this error to be possible in a well-formed state,
+      but you never know -/
+      | throwError "Failed to find local variable for state {stateExpr}"
+    pure state.userName
+
+  -- Try to find `h_program`, and infer `program` from it
+  let program ← mkFreshExprMVar none
+  let h_program_type ← mkEq (← mkAppM ``ArmState.program #[stateExpr]) program
+  let h_program ← findLocalDeclUsernameOfTypeOrError h_program_type
+
+  -- Assert that `program` is a(n application of a) constant, and find its name
+  let program := (← instantiateMVars program).getAppFn
+  let .const program _ := program
+    | withErrorContext h_run h_run_type <|
+        throwError "Expected a constant, found:\n\t{program}"
+  /-
+    TODO: assert that the expected `stepi` theorems have been generated
+  -/
+
+  -- Then, try to find `h_pc`
+  let pc ← mkFreshExprMVar (← mkAppM ``BitVec #[toExpr 64])
+  let h_pc_type ← do
+    let lhs ← mkAppM ``r #[(.const ``StateField.PC []), stateExpr]
+    mkEq lhs pc
+  let h_pc ← findLocalDeclUsernameOfTypeOrError h_pc_type
+
+  -- Unwrap and reflect `pc`
+  let pc ← instantiateMVars pc
+  let pc ← withErrorContext h_pc h_pc_type <| reflectBitVecLiteral 64 pc
+
+  return inferStatePrefixAndNumber {
+    state, h_run, runSteps, program, h_program, pc, h_pc,
+    h_err := none,
+    h_sp := none,
+  }
+where
+  findLocalDeclUsernameOfType? (expectedType : Expr) : MetaM (Option Name) := do
+    let some fvarId ← findLocalDeclWithType? expectedType
+      | return none
+    let decl := (← getLCtx).get! fvarId
+    -- ^^ `findLocalDeclWithType?` only returns `FVarId`s which are present in
+    --    the local context, so we can safely pass it to `get!`
+    return decl.userName
+  findLocalDeclUsernameOfTypeOrError (expectedType : Expr) : MetaM Name := do
+    let some name ← findLocalDeclUsernameOfType? expectedType
+      | throwError "Failed to find a local hypothesis of type {expectedType}"
+    return name
+
+
+def default (curr_state_number : Nat) : SymContext :=
+  let s := s!"s{curr_state_number}"
+  {
+    state     := .mkSimple s
+    h_run     := .mkSimple s!"h_run"
+    h_program := .mkSimple s!"h_{s}_program"
+    h_pc      := .mkSimple s!"h_{s}_pc"
+    h_err     := some <| .mkSimple s!"h_{s}_err"
+    h_sp      := some <| .mkSimple s!"h_{s}_sp"
+    /-
+      `runSteps`, `pc` and `program` actually require inspection of the context.
+      However, these values are not actually used yet,
+      they are merely kept because they will be useful in the future.
+      We can safely put in bogus values for now.
+      (Or we could do the honest thing and make these `Option`s)
+    -/
+    runSteps  := 9999999999
+    program   := `UNUSED
+    pc        := 0#64
+  }
+
+/-! ## Incrementing the context to the next state -/
+
+/-- `c.nextState` generates names for the next intermediate state in
+symbolic evaluation.
+
+`nextPc?`, if given, will be the pc of the next context.
+If `nextPC?` is `none`, then the previous pc is incremented by 4 -/
+def nextState (c : SymContext) (nextPc? : Option (BitVec 64) := none) :
+    SymContext :=
+  let curr_state_number := c.curr_state_number + 1
+  let s := s!"{c.state_prefix}{curr_state_number}"
+  {
+    state     := .mkSimple s
+    h_run     := c.h_run
+    h_program := .mkSimple s!"h_{s}_program"
+    h_pc      := .mkSimple s!"h_{s}_pc"
+    h_err     := some <| .mkSimple s!"h_{s}_err"
+    h_sp      := some <| .mkSimple s!"h_{s}_sp"
+    runSteps  := c.runSteps - 1
+    program   := c.program
+    pc        := nextPc?.getD (c.pc + 4#64)
+    curr_state_number
+    state_prefix := c.state_prefix
+  }
+
+/-! ## Simple projections -/
+open Lean (Ident mkIdent)
+
+def state_ident     (c : SymContext) : Ident := mkIdent c.state
+def h_run_ident     (c : SymContext) : Ident := mkIdent c.h_run
+def h_program_ident (c : SymContext) : Ident := mkIdent c.h_program
+def h_pc_ident      (c : SymContext) : Ident := mkIdent c.h_pc
+def h_err_ident     (c : SymContext) : Option Ident := mkIdent <$> c.h_err
+def h_sp_ident      (c : SymContext) : Option Ident := mkIdent <$> c.h_sp

--- a/Tests/Tactics/Sym.lean
+++ b/Tests/Tactics/Sym.lean
@@ -1,0 +1,17 @@
+import Proofs.«AES-GCM».GCMGmultV8Sym
+
+namespace GCMGmultV8Program
+
+-- Test the behaviour of `sym1_n` when `h_err` and `h_sp` are not present
+/-- warning: declaration uses 'sorry' -/ -- `guard_msgs` silences the warning
+#guard_msgs in example (s0 sf : ArmState)
+    (h_s0_program : s0.program = gcm_gmult_v8_program)
+    (h_s0_pc : read_pc s0 = gcm_gmult_v8_program.min)
+    (h_run : sf = run gcm_gmult_v8_program.length s0) :
+    read_err sf = .None := by
+  simp (config := {ground := true}) only [Option.some.injEq] at h_s0_pc h_run
+  sym1_n 1
+  · sorry
+  · exact (sorry : CheckSPAlignment s0)
+  · exact (sorry : read_err s0 = .None)
+  done


### PR DESCRIPTION
### Description:

Expands upon #69 to include context search for `h_err` and `h_sp`.
These assumptions are not strictly required, since we don't reflect information from them, 
so if they are not present we  introduce a new goal for them (in contrast to the other hypotheses, for which we simply throw an error).

### Testing:

`make all` succeeds, including conformance testing

### License:

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
